### PR TITLE
Bump rake to 12.3.3 to address vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
-    rake (12.3.1)
+    rake (12.3.3)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -56,4 +56,4 @@ DEPENDENCIES
   rspec_junit_formatter (~> 0.4)
 
 BUNDLED WITH
-   1.16.3
+   1.17.2


### PR DESCRIPTION
Addressed Rake vulnerability published at https://github.com/advisories/GHSA-jppv-gw3r-w3q8. (Enumpath v0.1.1 was not vulnerable.)