### PR TITLE
Fix Proc error on Ruby 3.0, bump some dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     benchmark-perf (0.2.1)
     byebug (10.0.2)
     coderay (1.1.2)
-    diff-lcs (1.3)
+    diff-lcs (1.4.4)
     method_source (0.9.0)
     mini_cache (1.1.0)
     null-logger (0.1.5)
@@ -22,22 +22,22 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     rake (12.3.3)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
     rspec-benchmark (0.3.0)
       benchmark-perf (~> 0.2.0)
       rspec (>= 3.0.0, < 4.0.0)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.1)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     to_regexp (0.2.1)
@@ -47,7 +47,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 2.2)
   enumpath!
   null-logger (~> 0.1)
   pry-byebug (~> 3.6)
@@ -58,4 +58,4 @@ DEPENDENCIES
   yard (~> 0.9.26)
 
 BUNDLED WITH
-   1.17.2
+   2.2.15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    enumpath (0.1.1)
+    enumpath (0.1.2)
       mini_cache (~> 1.1.0)
       to_regexp (~> 0.2.1)
 
@@ -47,7 +47,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.2)
+  bundler (~> 2.1)
   enumpath!
   null-logger (~> 0.1)
   pry-byebug (~> 3.6)

--- a/enumpath.gemspec
+++ b/enumpath.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mini_cache', '~> 1.1.0'
   spec.add_dependency 'to_regexp', '~> 0.2.1'
 
-  spec.add_development_dependency 'bundler', '~> 2.2'
+  spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'null-logger', '~> 0.1'
   spec.add_development_dependency 'pry-byebug', '~> 3.6'
   spec.add_development_dependency 'rake', '~> 12.3'

--- a/enumpath.gemspec
+++ b/enumpath.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mini_cache', '~> 1.1.0'
   spec.add_dependency 'to_regexp', '~> 0.2.1'
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler', '~> 2.2'
   spec.add_development_dependency 'null-logger', '~> 0.1'
   spec.add_development_dependency 'pry-byebug', '~> 3.6'
   spec.add_development_dependency 'rake', '~> 12.3'

--- a/lib/enumpath.rb
+++ b/lib/enumpath.rb
@@ -48,7 +48,7 @@ module Enumpath
     # @private
     # @see Enumpath::Logger#log
     def log(title)
-      block_given? ? logger.log(title, &Proc.new) : logger.log(title)
+      block_given? ? logger.log(title, &-> { yield }) : logger.log(title)
     end
 
     # A lightweight in-memory cache for caching normalized path expressions

--- a/lib/enumpath/version.rb
+++ b/lib/enumpath/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Enumpath
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/enumpath_spec.rb
+++ b/spec/enumpath_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Enumpath do
     it 'passes the :result_type option through to Enumpath::Path#new' do
       result_type = :path
       expect(Enumpath::Path).to receive(:new).with(path, result_type: result_type).and_call_original
-      Enumpath.apply(path, enum, result_type: :path)
+      Enumpath.apply(path, enum, result_type: result_type)
     end
 
     it 'calls #apply with enum on the Enumpath::Path instance' do


### PR DESCRIPTION
Address `tried to create Proc object without a block` errors on Ruby 3.0. Also bump some dependencies to fix a `kwargs` problem when using `and_call_original` from `rspec-mocks` on Ruby 3.0.